### PR TITLE
PKG-8968 cassandra driver 3.29.2 version update

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,12 +6,8 @@ package:
   version: {{ version }}
 
 source:
-  - url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-    sha256: c4310a7d0457f51a63fb019d8ef501588c491141362b53097fbc62fa06559b7c
-  # No'tests' folder in the pypi tarball. Download whole source from github for testing purposes.
-  - url: https://github.com/datastax/python-driver/archive/refs/tags/{{ version }}.tar.gz
-    sha256: aa3be5396e05b395c178091656a329daba23b0d4dd69b8d076090157f86e6d13
-    folder: gh_src
+  url: https://github.com/datastax/python-driver/archive/refs/tags/{{ version }}.tar.gz
+  sha256: aa3be5396e05b395c178091656a329daba23b0d4dd69b8d076090157f86e6d13
 
 build:
   skip: true  # [py<38 or py>312]
@@ -25,6 +21,7 @@ requirements:
     - {{ compiler('c') }}
   host:
     - python
+    - wheel
     - setuptools
     - cython >=0.20,!=0.25,<0.30
     - libev  # [not win]
@@ -33,15 +30,18 @@ requirements:
     - numpy
     - geomet >=0.1,<0.3
     - libev  # [not win]
+  run_constrained:
+    - gremlinpython >=3.4.6
+    - cryptography >=35.0
 
 # Skip due to missing dependencies (puresasl and pyximport).
 # Also, don't run integration tests because they require
 # Cassandra Cluster Manager to be running (no such dependency).
 {% set unit_tests_to_skip = [
-    "gh_src/tests/unit/advanced/test_auth.py",
-    "gh_src/tests/unit/cython/test_bytesio.py",
-    "gh_src/tests/unit/cython/test_types.py",
-    "gh_src/tests/unit/cython/test_utils.py"
+    "tests/unit/advanced/test_auth.py",
+    "tests/unit/cython/test_bytesio.py",
+    "tests/unit/cython/test_types.py",
+    "tests/unit/cython/test_utils.py"
 ] %}
 
 test:
@@ -57,7 +57,7 @@ test:
     - cassandra.datastax.cloud
     - cassandra.column_encryption
   source_files:
-    - gh_src/tests
+    - tests
   requires:
     - pip
     - pytest
@@ -69,9 +69,9 @@ test:
     # limit testing up to python 3.11 as it fails on python 3.12 due to asyncio changes
     # and libev requirement.
     # For OSX, skip as well a test that fails ocasionally with python 3.9.
-    - pytest -v gh_src/tests/unit {% for skip in unit_tests_to_skip %}--ignore={{ skip }} {% endfor %} # [linux]
-    - pytest -v gh_src/tests/unit {% for skip in unit_tests_to_skip %}--ignore={{ skip }} {% endfor %} -k "not test_empty_connections" # [osx]
-    - pytest -v gh_src/tests/unit {% for skip in unit_tests_to_skip %}--ignore={{ skip }} {% endfor %} -k "not test_deserialize_date_range_year" # [win and py<312]
+    - pytest -v tests/unit {% for skip in unit_tests_to_skip %}--ignore={{ skip }} {% endfor %} # [linux]
+    - pytest -v tests/unit {% for skip in unit_tests_to_skip %}--ignore={{ skip }} {% endfor %} -k "not test_empty_connections" # [osx]
+    - pytest -v tests/unit {% for skip in unit_tests_to_skip %}--ignore={{ skip }} {% endfor %} -k "not test_deserialize_date_range_year" # [win and py<312]
 
 about:
   home: https://github.com/datastax/python-driver

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,57 +1,90 @@
 {% set name = "cassandra-driver" %}
-{% set version = "3.25.0" %}
-{% set sha256 = "8ad7d7c090eb1cac6110b3bfc1fd2d334ac62f415aac09350ebb8d241b7aa7ee" %}
+{% set version = "3.29.2" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.tar.gz
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  - url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+    sha256: c4310a7d0457f51a63fb019d8ef501588c491141362b53097fbc62fa06559b7c
+  # No'tests' folder in the pypi tarball. Download whole source from github for testing purposes.
+  - url: https://github.com/datastax/python-driver/archive/refs/tags/{{ version }}.tar.gz
+    sha256: aa3be5396e05b395c178091656a329daba23b0d4dd69b8d076090157f86e6d13
+    folder: gh_src
 
 build:
+  skip: true  # [py<38 or py>312]
   number: 0
-  script: python setup.py build build_ext -I${PREFIX}/include -L${PREFIX}/lib install --single-version-externally-managed --record record.txt  # [not win]
-  script: python setup.py install --no-cython --single-version-externally-managed --record record.txt  # [win]
-  skip: true  # [py2k]
+  script: {{ PYTHON }} setup.py build build_ext -I${PREFIX}/include -L${PREFIX}/lib install --single-version-externally-managed --record record.txt  # [not win]
+  script: {{ PYTHON }} setup.py install --no-cython --single-version-externally-managed --record record.txt  # [win]
 
 requirements:
   build:
+    - {{ stdlib('c') }}
     - {{ compiler('c') }}
   host:
     - python
     - setuptools
-    - cython
+    - cython >=0.20,!=0.25,<0.30
     - libev  # [not win]
-    - msinttypes  # [win and py2k]
-
   run:
     - python
     - numpy
-    - six >=1.9
-    - futures <=2.2.0  # [py2k]
+    - geomet >=0.1,<0.3
     - libev  # [not win]
+
+# Skip due to missing dependencies (puresasl and pyximport).
+# Also, don't run integration tests because they require
+# Cassandra Cluster Manager to be running (no such dependency).
+{% set unit_tests_to_skip = [
+    "gh_src/tests/unit/advanced/test_auth.py",
+    "gh_src/tests/unit/cython/test_bytesio.py",
+    "gh_src/tests/unit/cython/test_types.py",
+    "gh_src/tests/unit/cython/test_utils.py"
+] %}
 
 test:
   imports:
     - cassandra
-    - cassandra.cqlengine
     - cassandra.io
-    - cassandra.numpy_parser  # [not win and python_impl == 'cpython']
+    - cassandra.cqlengine
+    - cassandra.graph
+    - cassandra.datastax
+    - cassandra.datastax.insights
+    - cassandra.datastax.graph
+    - cassandra.datastax.graph.fluent
+    - cassandra.datastax.cloud
+    - cassandra.column_encryption
+  source_files:
+    - gh_src/tests
+  requires:
+    - pip
+    - pytest
+    - eventlet
+  commands:
+    - pip check
+    - python -c "import cassandra; print(cassandra.__version__)"
+    # For Windows, skip as well a test that overflows timestamp limits for this OS. Also,
+    # limit testing up to python 3.11 as it fails on python 3.12 due to asyncio changes
+    # and libev requirement.
+    # For OSX, skip as well a test that fails ocasionally with python 3.9.
+    - pytest -v gh_src/tests/unit {% for skip in unit_tests_to_skip %}--ignore={{ skip }} {% endfor %} # [linux]
+    - pytest -v gh_src/tests/unit {% for skip in unit_tests_to_skip %}--ignore={{ skip }} {% endfor %} -k "not test_empty_connections" # [osx]
+    - pytest -v gh_src/tests/unit {% for skip in unit_tests_to_skip %}--ignore={{ skip }} {% endfor %} -k "not test_deserialize_date_range_year" # [win and py<312]
 
 about:
-  home: http://github.com/datastax/python-driver
-  license: Apache
-  license_family: Apache
+  home: https://github.com/datastax/python-driver
+  license:  Apache-2.0
+  license_family: APACHE
   license_file: LICENSE
-  summary: Python driver for Cassandra
+  summary: DataStax Driver for Apache Cassandra
   description: |
     A modern, feature-rich and highly-tunable Python client library for Apache Cassandra (2.1+)
-    using exclusively Cassandra’s binary protocol and Cassandra Query Language v3.
-  doc_url: http://datastax.github.io/python-driver/api/index.html
-  dev_url: http://github.com/datastax/python-driver
+    and DataStax Enterprise (4.7+) using exclusively Cassandra's binary protocol and
+    Cassandra Query Language v3.
+  doc_url: https://docs.datastax.com/en/developer/python-driver/3.29/index.html
+  dev_url: https://github.com/datastax/python-driver/tree/3.29.2
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,20 +6,21 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/datastax/python-driver/archive/refs/tags/{{ version }}.tar.gz
+  url: https://github.com/datastax/python-{{ name.split('-')[1] }}/archive/refs/tags/{{ version }}.tar.gz
   sha256: aa3be5396e05b395c178091656a329daba23b0d4dd69b8d076090157f86e6d13
 
 build:
+  # Python version limited based on documentation and cython availability up to python 3.12
   skip: true  # [py<38 or py>312]
   number: 0
-  script: {{ PYTHON }} setup.py build build_ext -I${PREFIX}/include -L${PREFIX}/lib install --single-version-externally-managed --record record.txt  # [not win]
-  script: {{ PYTHON }} setup.py install --no-cython --single-version-externally-managed --record record.txt  # [win]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   build:
     - {{ stdlib('c') }}
     - {{ compiler('c') }}
   host:
+    - pip
     - python
     - wheel
     - setuptools


### PR DESCRIPTION
cassandra driver 3.29.2

**Destination channel:** defaults

### Links

- [PKG-8968](https://anaconda.atlassian.net/browse/PKG-8968)
- dev_url: https://github.com/datastax/python-driver/tree/3.29.2
- conda_forge: https://github.com/conda-forge/cassandra-driver-feedstock
- pypi: https://pypi.org/project/cassandra-driver/
- build: https://package-build.anaconda.com/v1/graph/4bee4e0a-7a7c-4608-bfe8-66f4f65ca73e

### Explanation of changes:

- Update version to 3.29.2
- Add testing


[PKG-8968]: https://anaconda.atlassian.net/browse/PKG-8968?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ